### PR TITLE
Added an action callback to take action before blocking AcceptTcpClient.

### DIFF
--- a/Source/AsyncNet.Tcp/Server/AsyncNetTcpServer.cs
+++ b/Source/AsyncNet.Tcp/Server/AsyncNetTcpServer.cs
@@ -339,6 +339,8 @@ namespace AsyncNet.Tcp.Server
             {
                 try
                 {
+                    this.Config.ConfigureTcpListenerPendingCallback?.Invoke(tcpListener);
+
                     var tcpClient = await AcceptTcpClient(tcpListener, token).ConfigureAwait(false);
 
                     this.HandleNewTcpClientAsync(tcpClient, token);

--- a/Source/AsyncNet.Tcp/Server/AsyncNetTcpServerConfig.cs
+++ b/Source/AsyncNet.Tcp/Server/AsyncNetTcpServerConfig.cs
@@ -23,6 +23,8 @@ namespace AsyncNet.Tcp.Server
 
         public Action<TcpListener> ConfigureTcpListenerCallback { get; set; }
 
+        public Action<TcpListener> ConfigureTcpListenerPendingCallback { get; set; }
+
         public bool UseSsl { get; set; }
 
         public X509Certificate X509Certificate { get; set; }


### PR DESCRIPTION
I needed a way to simulate server not accepting in coming TCP connection requests. TcpListener::Pending is a synchronous function that returns true/false based on a pending tcp connection request. The call back function will let me configure on a pending request I can drop an in coming requests and simulate network outage scenario.

Please suggest if there are better ways of doing it.